### PR TITLE
Allow to pass custom arguments to prove

### DIFF
--- a/bin/auto-build-and-test-dist
+++ b/bin/auto-build-and-test-dist
@@ -10,4 +10,4 @@ build-dist
 cd "$BUILD_DIR"
 
 cpan-install-dist-deps --with-develop
-test-dist
+test-dist "$@"

--- a/bin/test-dist
+++ b/bin/test-dist
@@ -28,7 +28,7 @@ fi
 
 IFS=' ' read -r -a ALL_TEST_DIRS <<<"$TEST_DIRS"
 
-prove -lr --jobs 2 "${ALL_TEST_DIRS[@]}"
+prove -lr --jobs 2 "$@" "${ALL_TEST_DIRS[@]}"
 
 if [[ -n "${CODECOV_ENABLE}" ]]; then
     cover -report codecov


### PR DESCRIPTION
For example:
```
  auto-build-and-test-dist --state save
  auto-build-and-test-dist --jobs $(nproc --all)
  auto-build-and-test-dist -vm
```

Especially useful is `--state save` which allows to expose `.prove` as job's artifact for download and use to fix failed tests on localhost