### PR TITLE
New action `report-perl`

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ job:
     ...
     steps:
 	  ...
+      - uses: perl-actions/ci-perl-tester-helpers/report-perl@main
       - uses: perl-actions/ci-perl-tester-helpers/install-test-helper-deps@main
       - uses: perl-actions/ci-perl-tester-helpers/cpan-install-build-deps@main
       - uses: perl-actions/ci-perl-tester-helpers/build-dist@main
@@ -87,6 +88,31 @@ Install dependencies of your distribution.
 Install dependencies required by ci-perl-tester-helpers
 
 - `cpm` - required version min `0.997014`
+
+## perl-actions/ci-perl-tester-helpers/report-perl@main
+
+Report version and configuration of available Perl
+
+Despite being simple `perl -V` (for now) naming it shows intention what
+you want to do.
+
+### Inputs
+
+- `artifact` (optional): When specified, output will be written also to this file.
+
+### Examples
+
+Basic usage:
+```yaml
+- uses: perl-actions/ci-perl-tester-helpers/report-perl@main
+```
+
+Save output to a file:
+```yaml
+- uses: perl-actions/ci-perl-tester-helpers/report-perl@main
+  with:
+    artifact: perl-version.txt
+```
 
 ## perl-actions/ci-perl-tester-helpers/test-dist@main
 

--- a/report-perl/action.yml
+++ b/report-perl/action.yml
@@ -1,0 +1,13 @@
+---
+name: 'perl -V'
+inputs:
+  artifact:
+    description: 'File name where to save output of command'
+    required: false
+    default: '/dev/null'
+runs:
+  using: "composite"
+  steps:
+    - shell: bash
+      run: |
+        perl -V | tee "${{ inputs.artifact }}"


### PR DESCRIPTION
Trivial action just to make list of steps to look fancy, see:
```
    steps:
	  ...
      - uses: perl-actions/ci-perl-tester-helpers/report-perl@main
      - uses: perl-actions/ci-perl-tester-helpers/install-test-helper-deps@main
      - uses: perl-actions/ci-perl-tester-helpers/cpan-install-build-deps@main
      - uses: perl-actions/ci-perl-tester-helpers/build-dist@main
      - uses: perl-actions/ci-perl-tester-helpers/cpan-install-dist-deps@main
      - uses: perl-actions/ci-perl-tester-helpers/test-dist@main
```

Action also supports optional saving output into file for later publish artifact